### PR TITLE
style: Refactor the code to follow eslint:recommended

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+public/dist

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env":{
         "browser": true,
         "node": true,

--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ Prod:
 PORT=SOMEPORT npm start
 ```
 
+### Linting
+
+Check the code using:
+
+```bash
+npm run lint
+```
+
+To automatically fix errors:
+
+```bash
+npm run lint-fix
+```
+
 ## Docker
 
 ### Build docker image

--- a/app.js
+++ b/app.js
@@ -34,7 +34,7 @@ app.use(function(req, res, next) {
 });
 
 // error handler
-app.use(function(err, req, res, next) {
+app.use(function(err, req, res, next) { // eslint-disable-line no-unused-vars
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "refreshServer": "npx nodemon ./bin/www",
     "dev": "concurrently \"npm run watchBuild\" \"npm run refreshServer\"",
     "generate-docs": "npx jsdoc -c jsdoc.json",
-    "pretest": "npx eslint --fix --ignore-path .gitignore ."
+    "lint": "eslint .",
+    "lint-fix": "eslint --fix ."
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -1,7 +1,8 @@
-import {postData, fetchJson, service, openPage} from "./comms.js";
+import {postData, fetchJson, openPage} from "./comms.js";
 import {loginUser, logoutUser,registerUser } from "./user.js";
 import {openInitialPage} from "./home.js";
 import {renderAlertMessage, clearAlertMessage} from "./ui.js"
+import {readMineId} from '../mineIDs.js'
 
 /* Possible polyfills we'll want:
  * - Fetch
@@ -17,68 +18,11 @@ export default (function() {
     }
   }
 
-  function replaceText(elemId, text) {
-    var elem = document.getElementById(elemId);
-    var text = document.createTextNode(text);
-    removeChildren(elem);
-    elem.appendChild(text);
-  }
-
-  // Since our server (not the API) doesn't know whether the user is
-  // authenticated, checking for this and sending them to the `/register` page
-  // is a common pattern. We codify this here, so that we can use it in our
-  // generic request functions below.
-  function handleErrorResponse(res) {
-    if (res.status === 401) {
-      // The user isn't authorized, so make them sign in.
-      openPage("/register");
-      return new Error("You are not authorized.");
-    } else {
-      return res;
-    }
-  }
-
-  function fetchJson(path) {
-    return new Promise(function(resolve, reject) {
-      fetch(service(path), {
-        credentials: 'include'
-      })
-        .then(function(res) {
-          if (res.ok) {
-            return res.json();
-          } else {
-            reject(handleErrorResponse(res));
-          }
-        })
-        .then(function(data) {
-          resolve(data);
-        });
-    });
-  }
-
-  function postData(path, data) {
-    return new Promise(function(resolve, reject) {
-      fetch(service(path), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
-        credentials: 'include'
-      }).then(function(res) {
-        if (res.ok) {
-          resolve(res);
-        } else {
-          reject(handleErrorResponse(res));
-        }
-      })
-    });
-  }
-
-
   /*
    * Page: dashboard
    */
 
-  function openInProgressMine(mine) {
+  function openInProgressMine(mine) { // eslint-disable-line no-unused-vars
     // TODO
   }
 
@@ -371,7 +315,7 @@ export default (function() {
       path: "/configurator/mine/descriptors",
       params: { mineId: readMineId() }
     }, { mineName: mineName, privacy: privacy })
-      .then(function(res) {
+      .then(function() {
         // TODO handle case where `mineName` is already taken
         openPage("/wizard/finalise");
       });

--- a/public/js/mineIDs.js
+++ b/public/js/mineIDs.js
@@ -1,7 +1,7 @@
 import { fetchJson, saveStorage, loadStorage} from "./comms.js";
 
   function createMineId() {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve) {
       fetchJson("/configurator/mine/user-config/new/")
         .then(function(mineId) {
           saveStorage("mineId", mineId);

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -1,5 +1,4 @@
 import {fetchJson} from './comms.js';
-import {logoutUser} from "./user.js";
 import {removeChildren} from './ui.js';
 
 /*

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -61,9 +61,9 @@ function removeChildren(node) {
 
 function replaceText(elemId, text) {
   var elem = document.getElementById(elemId);
-  var text = document.createTextNode(text);
+  var textNode = document.createTextNode(text);
   removeChildren(elem);
-  elem.appendChild(text);
+  elem.appendChild(textNode);
 }
 
 

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -1,4 +1,4 @@
-import {fetchJson,postData, openPage, service} from "./comms.js";
+import {fetchJson,postData, openPage} from "./comms.js";
 import {clearAlertMessage, renderAlertMessage} from "./ui.js";
 import {openInitialPage} from "./home.js";
 
@@ -63,7 +63,7 @@ import {openInitialPage} from "./home.js";
 
     if (inputData) {
       postData("/user/register", inputData)
-        .then(function(registerRes) {
+        .then(function() {
           renderAlertMessage("alertbox", "Account created successfully.");
         })
         .catch(function(errRes) {
@@ -98,7 +98,7 @@ import {openInitialPage} from "./home.js";
 
     if (inputData) {
       postData("/user/login", inputData)
-        .then(function(loginRes) {
+        .then(function() {
           openInitialPage();
         });
       // TODO handle invalid login (I don't think the backend currently gives

--- a/public/js/wizard/mapColumns.js
+++ b/public/js/wizard/mapColumns.js
@@ -1,6 +1,6 @@
-import {service, saveStorage, loadStorage, openPage, postData} from '../comms.js';
+import {loadStorage, openPage, postData} from '../comms.js';
 import {readMineId} from '../mineIDs.js';
-import {removeChildren, replaceText} from '../ui.js';
+import {replaceText} from '../ui.js';
 
  /*
  * Page: wizard/mapColumns
@@ -109,7 +109,7 @@ function saveMapColumns() {
     path: "/configurator/file/properties/save",
     params: { mineId: readMineId() }
   }, { dataFile: uploadedFile , answers: answers })
-    .then(function(res) {
+    .then(function() {
       openPage("/wizard/supplementaryData");
     });
 }

--- a/public/js/wizard/upload.js
+++ b/public/js/wizard/upload.js
@@ -1,4 +1,4 @@
-import {service, saveStorage, loadStorage, openPage} from '../comms.js'
+import {postData, service, saveStorage, openPage} from '../comms.js'
 import {readMineId} from '../mineIDs.js'
 import {removeChildren} from '../ui.js'
 
@@ -40,7 +40,7 @@ function uploadFile() {
     // TODO test uploading of remote URLs
     // (I don't think this is handled by our backend yet.)
     postData("/data/file/upload/remote", { remoteUrl: remoteUrl })
-      .then(function(res) {
+      .then(function() {
         openPage("/wizard/mapColumns");
       });
   } else if (files.length) {
@@ -73,7 +73,7 @@ function uploadFile() {
       } catch(err) {
         renderUploadAlert(err.message);
       }
-    }).catch(function(err) {
+    }).catch(function() {
       renderUploadAlert("Failed to upload file.");
     });
   } else {
@@ -90,7 +90,7 @@ var initFileDialogue = function() {
     realFile.click();
   });
 
-  realFile.addEventListener("change", function(file) {
+  realFile.addEventListener("change", function() {
     var fileName = this.files[0].name;
     document.getElementById("fileName").innerHTML = fileName;
   });

--- a/routes/dev.js
+++ b/routes/dev.js
@@ -3,7 +3,7 @@ var router = express.Router();
 var templatePath = "dev/"
 
 /* GET default page. */
-router.get('/', function(req, res, next) {
+router.get('/', function(req, res) {
   res.render(templatePath + 'index');
 });
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,11 +2,11 @@ var express = require('express');
 var router = express.Router();
 
 /* GET home page. */
-router.get('/', function(req, res, next) {
+router.get('/', function(req, res) {
   res.render('home');
 });
 
-router.get('/register', function(req, res, next) {
+router.get('/register', function(req, res) {
   res.render('register');
 });
 
@@ -16,12 +16,12 @@ router.get('/register', function(req, res, next) {
 
 /* TODO ADD individual mine routing */
 
-router.get('/config', function(req, res, next) {
+router.get('/config', function(req, res) {
   res.render('mine-config');
 });
 
 /* GET mine builder dashboard. Currently same as default */
-router.get('/dashboard', function(req, res, next) {
+router.get('/dashboard', function(req, res) {
   res.render('dashboard');
 });
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -2,7 +2,7 @@ var express = require('express');
 var router = express.Router();
 
 /* GET users listing. */
-router.get('/profile', function(req, res, next) {
+router.get('/profile', function(req, res) {
   res.render('users/profile');
 });
 

--- a/routes/wizard.js
+++ b/routes/wizard.js
@@ -4,19 +4,15 @@ var templatePath = "wizard/"
 var wizardSteps = require('../views/wizard/wizardSteps.js')
 
 /* GET default page. */
-router.get('/', function(req, res, next) {
+router.get('/', function(req, res) {
   res.render(templatePath + 'upload', {steps: wizardSteps.steps});
 });
 
 /* Dynamically generate wizard pages based on the views/wizard/wizardSteps config */
 wizardSteps.steps.map(function(step) {
-  router.get('/' + step.name, function(req, res, next) {
+  router.get('/' + step.name, function(req, res) {
     res.render(templatePath + step.name, {steps: wizardSteps.steps});
   });
 })
-
-
-
-
 
 module.exports = router;


### PR DESCRIPTION
- Refactor the code to follow the style rules defined in the project: [eslint:recommended](https://eslint.org/docs/rules/)
- Remove duplicate code
- Ignore the `public/dist` directory when linting the project by defining an `.eslintignore` config. Ideally we should exclude this directoty from git (in `.gitignore`) which will automatically exclude it from ESLint checks.
- Added documentation about how to run ESLint
- Simplify the linting-related npm scripts

Fix #14, #15