### PR TITLE
Startup script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Fixes permission error due to directory you don't have permission to access
+# being included in the build context when building wizard Dockerfile.
+data/

--- a/bin/init-dependencies.sh
+++ b/bin/init-dependencies.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script could be tidied up by handling container naming conflicts
+# for now it assumes there is a fresh environment with docker running
+
+cd ..
+
+echo "---> cloning InterMine Compose"
+git clone https://github.com/intermine/intermine_compose
+
+echo "---> cloning InterMine Configurator"
+git clone https://github.com/intermine/intermine_configurator
+
+echo "---> running server startup scripts"
+cd wizard
+source bin/startup.sh

--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script could be tidied up by handling container naming conflicts
+# for now it assumes there is a fresh environment with docker running
+
+cd ../intermine_compose
+docker build -t intermine/compose:latest .
+cd ../intermine_configurator
+docker build -t intermine/configurator:latest .
+cd ../wizard
+
+docker-compose up --build --force-recreate

--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -2,6 +2,8 @@
 
 # This script could be tidied up by handling container naming conflicts
 # for now it assumes there is a fresh environment with docker running
+# AND you have the relevant directories cloned. If you don't, run
+# init-dependencies.sh from the root of the wizard repo
 
 cd ../intermine_compose
 docker build -t intermine/compose:latest .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,13 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
     volumes:
       - ${POSTGRES_DATA_PATH:-./data/postgres}:/var/lib/postgresql/data
-  
+
   redis:
     container_name: compose_redis
     image: redis:alpine
     volumes:
       - ${REDIS_DATA_PATH:-./data/redis}:/data
-  
+
   configurator:
     container_name: configurator
     image: intermine/configurator:latest
@@ -26,10 +26,10 @@ services:
       - REDIS_PORT_ENV=${REDIS_PORT_ENV:-6379}
     volumes:
       - SharedFS:${IM_DATA_DIR:-/intermine/sharedfs}
-    depends_on: 
+    depends_on:
       - redis
     ports:
-      - ${CONFIGURATOR_HOST_PORT:-9999}:${CONFIGURATOR_PORT:-8080}
+      - ${CONFIGURATOR_HOST_PORT:-9999}:${CONFIGURATOR_PORT:-8082}
   wizard:
     container_name: wizard
     build:
@@ -53,16 +53,15 @@ services:
       - PGUSER=${PGUSER:-postgres}
       - PGPASSWORD=${PGPASSWORD:-postgres}
       - IM_DATA_DIR=${IM_DATA_DIR:-/intermine/sharedfs}
-      - CONFIGURATOR_URL=${CONFIGURATOR_URL:-http://configurator:8080/}
+      - CONFIGURATOR_URL=${CONFIGURATOR_URL:-http://configurator:8082/}
     volumes:
       - SharedFS:${IM_DATA_DIR:-/intermine/sharedfs}
     ports:
       - ${COMPOSE_HOST_PORT:-9991}:${COMPOSE_PORT:-9991}
-    depends_on: 
+    depends_on:
       - postgres
       - configurator
       - redis
 
 volumes:
   SharedFS:
-


### PR DESCRIPTION
to test this: 

1. clone the wizard
2. cd into the wizard directory  
3. IF YOU DO NOT HAVE the wizard and configurator cloned in the same parent directory as the wizard, run: 
    1. `chmod +x bin/init-dependencies.sh`
    1. `./bin/init-dependencies.sh`
3. Otherwise, just run `chmod +x ./bin/startup.sh`

Ctrl+c will exit